### PR TITLE
substitute literature link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ bibliography
 "Distributing many points on a sphere"
 Saff, E.B. & Kuijlaars, A.B.J. (1997).
 The Mathematical Intelligencer, 19, 5-11,
-http://www.math.vanderbilt.edu/~esaff/texts/161.pdf
+https://doi.org/10.1007/BF03024331
 
 TODO
 ====


### PR DESCRIPTION
On [2022-11-22 Tue], the link previously provided yields an error 404 / site not found.  By provision of the doi eventually linking to the landing page of the publication, this issue is resolved.